### PR TITLE
Adds support for creating shared plans

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,7 +11,7 @@
 /hn-single-view-api/production/JigsawCustomerBaseSearchUrl=
 /hn-single-view-api/production/JigsawHomelessnessBaseSearchUrl=
 /hn-single-view-api/production/JigsawAccommodationBaseSearchUrl=
-
+/hn-single-view-api/production/SHARED_PLAN_BASE_URL=
 
 
 /hn-single-view-api/dev/UHW_DB=
@@ -27,6 +27,7 @@
 /hn-single-view-api/dev/JigsawCustomerBaseSearchUrl=
 /hn-single-view-api/dev/JigsawHomelessnessBaseSearchUrl=
 /hn-single-view-api/dev/JigsawAccommodationBaseSearchUrl=
+/hn-single-view-api/dev/SHARED_PLAN_BASE_URL=
 
 
 
@@ -45,6 +46,7 @@
 /hn-single-view-api/test/JigsawHomelessnessBaseSearchUrl=http://localhost:8080/homelessness
 /hn-single-view-api/test/JigsawAccommodationBaseSearchUrl=http://localhost:8080/accommodation
 SINGLEVIEW_DB=postgresql://singleview_user:@localhost:10102/hnsingleview 
+/hn-single-view-api/test/SHARED_PLAN_BASE_URL=
 ################
 
 /hn-single-view-api/SENTRY_DSN=

--- a/api/index.js
+++ b/api/index.js
@@ -10,7 +10,8 @@ const {
   fetchNotes,
   fetchRecords,
   saveCustomer,
-  deleteCustomer
+  deleteCustomer,
+  createSharedPlan
 } = require('./lib/libDependencies');
 
 if (process.env.ENV === 'staging' || process.env.ENV === 'production') {
@@ -106,6 +107,24 @@ app.get('/customers/:id/documents', async (req, res, next) => {
     console.timeEnd(`GET CUSTOMER DOCS id="${req.params.id}"`);
     res.send(results);
   } catch (err) {
+    next(err);
+  }
+});
+
+app.post('/customers/:id/shared-plans', async (req, res, next) => {
+  try {
+    console.time('create-shared-plan');
+    console.log('create shared plan', { params: req.params });
+
+    const { id: planId } = await createSharedPlan({
+      customerId: req.params.id,
+      token: res.locals.hackneyToken
+    });
+
+    console.timeEnd('create-shared-plan');
+    return res.send({ planId });
+  } catch (err) {
+    console.log('create shared plan failed', { error: err });
     next(err);
   }
 });

--- a/api/lib/gateways/SharedPlan/SharedPlanApi.js
+++ b/api/lib/gateways/SharedPlan/SharedPlanApi.js
@@ -1,0 +1,24 @@
+const rp = require('request-promise');
+
+class SharedPlanApi {
+  constructor({ baseUrl }) {
+    this.baseUrl = baseUrl;
+  }
+
+  async create({ customer, token }) {
+    const response = await rp(`${this.baseUrl}/`, {
+      method: 'POST',
+      auth: { bearer: token },
+      json: true,
+      body: {
+        firstName: customer.firstName,
+        lastName: customer.lastName,
+        systemIds: customer.systemIds
+      }
+    });
+
+    return { id: response.id };
+  }
+}
+
+module.exports = SharedPlanApi;

--- a/api/lib/libDependencies.js
+++ b/api/lib/libDependencies.js
@@ -228,6 +228,12 @@ const jigsawFetchNotesGateway = require('./gateways/Jigsaw/FetchNotes')({
   logger
 });
 
+// Other gateways
+const SharedPlanApi = require('./gateways/SharedPlan/SharedPlanApi');
+const sharedPlan = new SharedPlanApi({
+  baseUrl: process.env.SHARED_PLAN_BASE_URL
+});
+
 // USECASES
 
 const customerSearch = require('./use-cases/CustomerSearch')({
@@ -296,6 +302,11 @@ const deleteCustomer = require('./use-cases/DeleteCustomer')({
   gateway: deleteCustomerGateway
 });
 
+const createSharedPlan = require('./use-cases/CreateSharedPlan')({
+  fetchRecords,
+  sharedPlan
+});
+
 module.exports = {
   Sentry,
   customerSearch,
@@ -303,5 +314,6 @@ module.exports = {
   fetchRecords,
   fetchNotes,
   saveCustomer,
-  deleteCustomer
+  deleteCustomer,
+  createSharedPlan
 };

--- a/api/lib/use-cases/CreateSharedPlan.js
+++ b/api/lib/use-cases/CreateSharedPlan.js
@@ -1,5 +1,5 @@
 module.exports = ({ fetchRecords, sharedPlan }) => {
-  return async ({ customerId }) => {
+  return async ({ customerId, token }) => {
     const record = await fetchRecords(customerId);
 
     if (!record) {
@@ -11,7 +11,8 @@ module.exports = ({ fetchRecords, sharedPlan }) => {
         firstName: record.firstName,
         lastName: record.lastName,
         systemIds: [record.id, ...Object.values(record.systemIds)]
-      }
+      },
+      token
     });
 
     return plan;

--- a/api/lib/use-cases/CreateSharedPlan.js
+++ b/api/lib/use-cases/CreateSharedPlan.js
@@ -1,0 +1,19 @@
+module.exports = ({ fetchRecords, sharedPlan }) => {
+  return async ({ customerId }) => {
+    const record = await fetchRecords(customerId);
+
+    if (!record) {
+      throw new Error('Unable to create plan, unknown customer');
+    }
+
+    const plan = await sharedPlan.create({
+      customer: {
+        firstName: record.firstName,
+        lastName: record.lastName,
+        systemIds: [record.id, ...Object.values(record.systemIds)]
+      }
+    });
+
+    return plan;
+  };
+};

--- a/api/test/gateways/SharedPlan/SharedPlanApi.test.js
+++ b/api/test/gateways/SharedPlan/SharedPlanApi.test.js
@@ -1,0 +1,34 @@
+const nock = require('nock');
+const SharedPlanApi = require('../../../lib/gateways/SharedPlan/SharedPlanApi');
+
+describe('SharedPlanApi', () => {
+  describe('create', () => {
+    const expectedPlanId = 'SP-1';
+    const expectedToken = 'a-really-secure-token';
+
+    beforeEach(() => {
+      nock('https://shared.plan', {
+        reqheaders: {
+          authorization: `Bearer ${expectedToken}`
+        }
+      })
+        .post('/')
+        .reply(201, { id: expectedPlanId });
+    });
+
+    it('calls the API endpoint with a valid body', async () => {
+      const api = new SharedPlanApi({ baseUrl: 'https://shared.plan' });
+      const createdPlan = await api.create({
+        token: expectedToken,
+        customer: {
+          firstName: 'Stanley',
+          lastName: 'McTest',
+          systemIds: ['123', '456', '789']
+        }
+      });
+
+      expect(createdPlan.id).toBe(expectedPlanId);
+      expect(nock.isDone()).toBe(true);
+    });
+  });
+});

--- a/api/test/use-cases/CreateSharedPlan.test.js
+++ b/api/test/use-cases/CreateSharedPlan.test.js
@@ -1,0 +1,41 @@
+const createSharedPlan = require('../../lib/use-cases/CreateSharedPlan');
+
+describe('CreateSharedPlan', () => {
+  const expectedRecord = {
+    id: '123',
+    firstName: 'Bob',
+    lastName: 'Smith',
+    systemIds: {
+      ACADEMY: 'ACADEMY-123',
+      JIGSAW: 'JIGSAW-123'
+    }
+  };
+
+  const expectedPlanId = 'SP-1';
+
+  const container = {
+    sharedPlan: {
+      create: jest.fn(() => ({ id: expectedPlanId }))
+    },
+    fetchRecords: jest.fn(() => expectedRecord)
+  };
+
+  it('creates a shared plan using the customer details', async () => {
+    const execute = createSharedPlan(container);
+    const plan = await execute({ customerId: expectedRecord.id });
+
+    expect(container.sharedPlan.create).toHaveBeenCalledWith({
+      customer: {
+        firstName: expectedRecord.firstName,
+        lastName: expectedRecord.lastName,
+        systemIds: expect.arrayContaining([
+          expectedRecord.id,
+          expectedRecord.systemIds.ACADEMY,
+          expectedRecord.systemIds.JIGSAW
+        ])
+      }
+    });
+
+    expect(plan.id).toBe(expectedPlanId);
+  });
+});

--- a/api/test/use-cases/CreateSharedPlan.test.js
+++ b/api/test/use-cases/CreateSharedPlan.test.js
@@ -12,6 +12,7 @@ describe('CreateSharedPlan', () => {
   };
 
   const expectedPlanId = 'SP-1';
+  const expectedToken = 'a-very-secure-token';
 
   const container = {
     sharedPlan: {
@@ -22,7 +23,11 @@ describe('CreateSharedPlan', () => {
 
   it('creates a shared plan using the customer details', async () => {
     const execute = createSharedPlan(container);
-    const plan = await execute({ customerId: expectedRecord.id });
+
+    const plan = await execute({
+      customerId: expectedRecord.id,
+      token: expectedToken
+    });
 
     expect(container.sharedPlan.create).toHaveBeenCalledWith({
       customer: {
@@ -33,7 +38,8 @@ describe('CreateSharedPlan', () => {
           expectedRecord.systemIds.ACADEMY,
           expectedRecord.systemIds.JIGSAW
         ])
-      }
+      },
+      token: expectedToken
     });
 
     expect(plan.id).toBe(expectedPlanId);

--- a/package-lock.json
+++ b/package-lock.json
@@ -6611,6 +6611,18 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "nock": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-12.0.3.tgz",
+      "integrity": "sha512-QNb/j8kbFnKCiyqi9C5DD0jH/FubFGj5rt9NQFONXwQm3IPB0CULECg/eS3AU1KgZb/6SwUa4/DTRKhVxkGABw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.13",
+        "propagate": "^2.0.0"
+      }
+    },
     "node-dir": {
       "version": "0.1.17",
       "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
@@ -7294,6 +7306,12 @@
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.3"
       }
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
     },
     "proto-list": {
       "version": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "node-lambda-authorizer": "LBHackney-IT/node-lambda-authorizer.git#dfc45f0"
   },
   "devDependencies": {
+    "nock": "^12.0.3",
     "eslint": "^6.6.0",
     "eslint-config-prettier": "^6.5.0",
     "eslint-plugin-prettier": "^3.1.1",

--- a/serverless-api.yml
+++ b/serverless-api.yml
@@ -59,6 +59,7 @@ functions:
       JIGSAW_DOCUMENTS_API: ${ssm:/hn-single-view-api/${self:provider.stage}/JIGSAW_DOCUMENTS_API}
       ENV: ${self:provider.stage}
       SENTRY_DSN: ${ssm:/hn-single-view-api/SENTRY_DSN}
+      SHARED_PLAN_BASE_URL: ${ssm:/hn-single-view-api/${self:provider.stage}/SHARED_PLAN_BASE_URL}
 
   hn-single-view-api-authorizer:
     name: hn-single-view-api-authorizer-${self:provider.stage}


### PR DESCRIPTION
**What**
Adds an API endpoint that supports creating shared plans, by calling the Shared Plan API using customer data and system ids that exist within Single View.

**Why**
So that we can add UI in the front-end that will enable users to securely create shared plans for customers.

**Extra bits**
 - This requires some additional configuration (the API endpoint for the Shared Plan API).