### PR TITLE
Adds support for finding existing shared plans

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -11,7 +11,8 @@ const {
   fetchRecords,
   saveCustomer,
   deleteCustomer,
-  createSharedPlan
+  createSharedPlan,
+  findSharedPlans
 } = require('./lib/libDependencies');
 
 if (process.env.ENV === 'staging' || process.env.ENV === 'production') {
@@ -125,6 +126,24 @@ app.post('/customers/:id/shared-plans', async (req, res, next) => {
     return res.send({ planId });
   } catch (err) {
     console.log('create shared plan failed', { error: err });
+    next(err);
+  }
+});
+
+app.get('/customers/:id/shared-plans', async (req, res, next) => {
+  try {
+    console.time('find-shared-plan');
+    console.log('find shared plan', { params: req.params });
+
+    const { planIds } = await findSharedPlans({
+      customerId: req.params.id,
+      token: res.locals.hackneyToken
+    });
+
+    console.timeEnd('find-shared-plan');
+    return res.send({ planIds });
+  } catch (err) {
+    console.log('find shared plans failed', { error: err });
     next(err);
   }
 });

--- a/api/lib/gateways/SharedPlan/SharedPlanApi.js
+++ b/api/lib/gateways/SharedPlan/SharedPlanApi.js
@@ -21,11 +21,11 @@ class SharedPlanApi {
   }
 
   async find({ firstName, lastName, systemIds, token }) {
-    const response = await rp(`${this.baseUrl}/plans`, {
-      method: 'GET',
+    const response = await rp(`${this.baseUrl}/plans/find`, {
+      method: 'POST',
       auth: { bearer: token },
       json: true,
-      qs: {
+      body: {
         firstName,
         lastName,
         systemIds

--- a/api/lib/gateways/SharedPlan/SharedPlanApi.js
+++ b/api/lib/gateways/SharedPlan/SharedPlanApi.js
@@ -6,7 +6,7 @@ class SharedPlanApi {
   }
 
   async create({ customer, token }) {
-    const response = await rp(`${this.baseUrl}/`, {
+    const response = await rp(`${this.baseUrl}/plans`, {
       method: 'POST',
       auth: { bearer: token },
       json: true,
@@ -18,6 +18,21 @@ class SharedPlanApi {
     });
 
     return { id: response.id };
+  }
+
+  async find({ firstName, lastName, systemIds, token }) {
+    const response = await rp(`${this.baseUrl}/plans`, {
+      method: 'GET',
+      auth: { bearer: token },
+      json: true,
+      qs: {
+        firstName,
+        lastName,
+        systemIds
+      }
+    });
+
+    return { planIds: response };
   }
 }
 

--- a/api/lib/gateways/SharedPlan/SharedPlanApi.js
+++ b/api/lib/gateways/SharedPlan/SharedPlanApi.js
@@ -32,7 +32,7 @@ class SharedPlanApi {
       }
     });
 
-    return { planIds: response };
+    return response;
   }
 }
 

--- a/api/lib/libDependencies.js
+++ b/api/lib/libDependencies.js
@@ -307,6 +307,11 @@ const createSharedPlan = require('./use-cases/CreateSharedPlan')({
   sharedPlan
 });
 
+const findSharedPlans = require('./use-cases/FindSharedPlans')({
+  fetchRecords,
+  sharedPlan
+});
+
 module.exports = {
   Sentry,
   customerSearch,
@@ -315,5 +320,6 @@ module.exports = {
   fetchNotes,
   saveCustomer,
   deleteCustomer,
-  createSharedPlan
+  createSharedPlan,
+  findSharedPlans
 };

--- a/api/lib/use-cases/FindSharedPlans.js
+++ b/api/lib/use-cases/FindSharedPlans.js
@@ -1,0 +1,18 @@
+module.exports = ({ fetchRecords, sharedPlan }) => {
+  return async ({ customerId, token }) => {
+    const record = await fetchRecords(customerId);
+
+    if (!record) {
+      throw new Error('Unable to find plans, unknown customer');
+    }
+
+    const { planIds } = await sharedPlan.find({
+      firstName: record.firstName,
+      lastName: record.lastName,
+      systemIds: [record.id, ...Object.values(record.systemIds)],
+      token
+    });
+
+    return { planIds };
+  };
+};

--- a/api/lib/use-cases/FindSharedPlans.js
+++ b/api/lib/use-cases/FindSharedPlans.js
@@ -1,14 +1,13 @@
 module.exports = ({ fetchRecords, sharedPlan }) => {
   return async ({ customerId, token }) => {
     const record = await fetchRecords(customerId);
-
     if (!record) {
       throw new Error('Unable to find plans, unknown customer');
     }
 
     const { planIds } = await sharedPlan.find({
-      firstName: record.firstName,
-      lastName: record.lastName,
+      firstName: record.name[0].first,
+      lastName: record.name[0].last,
       systemIds: [record.id, ...Object.values(record.systemIds)],
       token
     });

--- a/api/test/gateways/SharedPlan/SharedPlanApi.test.js
+++ b/api/test/gateways/SharedPlan/SharedPlanApi.test.js
@@ -42,10 +42,8 @@ describe('SharedPlanApi', () => {
           authorization: `Bearer ${expectedToken}`
         }
       })
-        .get(
-          '/plans?firstName=Stanley&lastName=McTest&systemIds=123&systemIds=456'
-        )
-        .reply(201, expectedPlanIds);
+        .post('/plans/find')
+        .reply(200, expectedPlanIds);
     });
 
     it('calls the API endpoint with valid querystring', async () => {

--- a/api/test/gateways/SharedPlan/SharedPlanApi.test.js
+++ b/api/test/gateways/SharedPlan/SharedPlanApi.test.js
@@ -12,7 +12,7 @@ describe('SharedPlanApi', () => {
           authorization: `Bearer ${expectedToken}`
         }
       })
-        .post('/')
+        .post('/plans')
         .reply(201, { id: expectedPlanId });
     });
 
@@ -28,6 +28,36 @@ describe('SharedPlanApi', () => {
       });
 
       expect(createdPlan.id).toBe(expectedPlanId);
+      expect(nock.isDone()).toBe(true);
+    });
+  });
+
+  describe('find', () => {
+    const expectedPlanIds = ['SP-1', 'SP-2'];
+    const expectedToken = 'a-really-secure-token';
+
+    beforeEach(() => {
+      nock('https://shared.plan', {
+        reqheaders: {
+          authorization: `Bearer ${expectedToken}`
+        }
+      })
+        .get(
+          '/plans?firstName=Stanley&lastName=McTest&systemIds=123&systemIds=456'
+        )
+        .reply(201, expectedPlanIds);
+    });
+
+    it('calls the API endpoint with valid querystring', async () => {
+      const api = new SharedPlanApi({ baseUrl: 'https://shared.plan' });
+      const { planIds } = await api.find({
+        token: expectedToken,
+        firstName: 'Stanley',
+        lastName: 'McTest',
+        systemIds: ['123', '456']
+      });
+
+      expect(planIds).toStrictEqual(expectedPlanIds);
       expect(nock.isDone()).toBe(true);
     });
   });

--- a/api/test/gateways/SharedPlan/SharedPlanApi.test.js
+++ b/api/test/gateways/SharedPlan/SharedPlanApi.test.js
@@ -33,7 +33,7 @@ describe('SharedPlanApi', () => {
   });
 
   describe('find', () => {
-    const expectedPlanIds = ['SP-1', 'SP-2'];
+    const expectedResponse = { planIds: ['SP-1', 'SP-2'] };
     const expectedToken = 'a-really-secure-token';
 
     beforeEach(() => {
@@ -43,7 +43,7 @@ describe('SharedPlanApi', () => {
         }
       })
         .post('/plans/find')
-        .reply(200, expectedPlanIds);
+        .reply(200, expectedResponse);
     });
 
     it('calls the API endpoint with valid querystring', async () => {
@@ -55,7 +55,7 @@ describe('SharedPlanApi', () => {
         systemIds: ['123', '456']
       });
 
-      expect(planIds).toStrictEqual(expectedPlanIds);
+      expect(planIds).toStrictEqual(expectedResponse.planIds);
       expect(nock.isDone()).toBe(true);
     });
   });

--- a/api/test/use-cases/FindSharedPlans.test.js
+++ b/api/test/use-cases/FindSharedPlans.test.js
@@ -1,0 +1,44 @@
+const findSharedPlans = require('../../lib/use-cases/FindSharedPlans');
+
+describe('CreateSharedPlan', () => {
+  const expectedRecord = {
+    id: '123',
+    firstName: 'Test',
+    lastName: 'Person',
+    systemIds: {
+      ACADEMY: 'ACADEMY-123',
+      JIGSAW: 'JIGSAW-123'
+    }
+  };
+
+  const expectedPlanIds = ['123', '456'];
+  const expectedToken = 'a-very-secure-token';
+
+  const container = {
+    sharedPlan: {
+      find: jest.fn(() => ({ planIds: expectedPlanIds }))
+    },
+    fetchRecords: jest.fn(() => expectedRecord)
+  };
+
+  it('finds plans using the customer details', async () => {
+    const execute = findSharedPlans(container);
+    const expectedCustomer = {
+      firstName: 'Test',
+      lastName: 'Person',
+      systemIds: ['123', 'ACADEMY-123', 'JIGSAW-123']
+    };
+
+    const { planIds } = await execute({
+      customerId: '123',
+      token: expectedToken
+    });
+
+    expect(container.sharedPlan.find).toHaveBeenCalledWith({
+      ...expectedCustomer,
+      token: expectedToken
+    });
+
+    expect(planIds).toBe(expectedPlanIds);
+  });
+});

--- a/api/test/use-cases/FindSharedPlans.test.js
+++ b/api/test/use-cases/FindSharedPlans.test.js
@@ -3,8 +3,12 @@ const findSharedPlans = require('../../lib/use-cases/FindSharedPlans');
 describe('CreateSharedPlan', () => {
   const expectedRecord = {
     id: '123',
-    firstName: 'Test',
-    lastName: 'Person',
+    name: [
+      {
+        first: 'Test',
+        last: 'Person'
+      }
+    ],
     systemIds: {
       ACADEMY: 'ACADEMY-123',
       JIGSAW: 'JIGSAW-123'


### PR DESCRIPTION
**What**
Adds support for finding a customers existing shared plans, by querying the Shared Plan API using their name and associated ids.

**Why**
So that in Single View, we can display a list of existing shared plans and allow officers to open them when viewing the single view record.