### PR TITLE
Add find/create vulnerabilities endpoints

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -12,6 +12,7 @@
 /hn-single-view-api/production/JigsawHomelessnessBaseSearchUrl=
 /hn-single-view-api/production/JigsawAccommodationBaseSearchUrl=
 /hn-single-view-api/production/SHARED_PLAN_BASE_URL=
+/hn-single-view-api/production/VULNERABILITIES_BASE_URL=
 
 
 /hn-single-view-api/dev/UHW_DB=
@@ -28,7 +29,7 @@
 /hn-single-view-api/dev/JigsawHomelessnessBaseSearchUrl=
 /hn-single-view-api/dev/JigsawAccommodationBaseSearchUrl=
 /hn-single-view-api/dev/SHARED_PLAN_BASE_URL=
-
+/hn-single-view-api/dev/VULNERABILITIES_BASE_URL=
 
 
 ### TEST ENV ###
@@ -47,6 +48,7 @@
 /hn-single-view-api/test/JigsawAccommodationBaseSearchUrl=http://localhost:8080/accommodation
 SINGLEVIEW_DB=postgresql://singleview_user:@localhost:10102/hnsingleview 
 /hn-single-view-api/test/SHARED_PLAN_BASE_URL=
+/hn-single-view-api/test/VULNERABILITIES_BASE_URL=
 ################
 
 /hn-single-view-api/SENTRY_DSN=

--- a/api/index.js
+++ b/api/index.js
@@ -12,7 +12,9 @@ const {
   saveCustomer,
   deleteCustomer,
   createSharedPlan,
-  findSharedPlans
+  findSharedPlans,
+  createVulnerabilitySnapshot,
+  findVulnerabilitySnapshots
 } = require('./lib/libDependencies');
 
 if (process.env.ENV === 'staging' || process.env.ENV === 'production') {
@@ -144,6 +146,42 @@ app.get('/customers/:id/shared-plans', async (req, res, next) => {
     return res.send({ planIds });
   } catch (err) {
     console.log('find shared plans failed', { error: err });
+    next(err);
+  }
+});
+
+app.post('/customers/:id/vulnerabilities', async (req, res, next) => {
+  try {
+    console.time('create-vulnerability-snapshot');
+    console.log('create vulnerability snapshot', { params: req.params });
+
+    const { id: snapshotId } = await createVulnerabilitySnapshot({
+      customerId: req.params.id,
+      token: res.locals.hackneyToken
+    });
+
+    console.timeEnd('create-vulnerability-snapshot');
+    return res.send({ snapshotId });
+  } catch (err) {
+    console.log('create vulnerability snapshot failed', { error: err });
+    next(err);
+  }
+});
+
+app.get('/customers/:id/vulnerabilities', async (req, res, next) => {
+  try {
+    console.time('find-vulnerability-snapshots');
+    console.log('find vulnerability snapshots', { params: req.params });
+
+    const { snapshotIds } = await findVulnerabilitySnapshots({
+      customerId: req.params.id,
+      token: res.locals.hackneyToken
+    });
+
+    console.timeEnd('find-vulnerability-snapshots');
+    return res.send({ snapshotIds });
+  } catch (err) {
+    console.log('find vulnerability snapshots', { error: err });
     next(err);
   }
 });

--- a/api/lib/gateways/Vulnerabilities/VulnerabilitiesApi.js
+++ b/api/lib/gateways/Vulnerabilities/VulnerabilitiesApi.js
@@ -1,0 +1,48 @@
+const rp = require('request-promise');
+
+class VulnerabilitiesApi {
+  constructor({ baseUrl }) {
+    this.baseUrl = baseUrl;
+  }
+
+  async create({ customer, token }) {
+    const response = await rp(`${this.baseUrl}/api/vulnerabilities`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`
+      },
+      json: true,
+      body: {
+        firstName: customer.firstName,
+        lastName: customer.lastName,
+        systemIds: customer.systemIds
+      }
+    });
+
+    return { id: response.id };
+  }
+
+  async find({ firstName, lastName, systemIds, token }) {
+    try {
+      const response = await rp(`${this.baseUrl}/api/vulnerabilities/find`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`
+        },
+        json: true,
+        body: {
+          firstName,
+          lastName,
+          systemIds
+        }
+      });
+      return response;
+    } catch (err) {
+      return {
+        snapshotIds: []
+      };
+    }
+  }
+}
+
+module.exports = VulnerabilitiesApi;

--- a/api/lib/libDependencies.js
+++ b/api/lib/libDependencies.js
@@ -229,9 +229,15 @@ const jigsawFetchNotesGateway = require('./gateways/Jigsaw/FetchNotes')({
 });
 
 // Other gateways
+
 const SharedPlanApi = require('./gateways/SharedPlan/SharedPlanApi');
 const sharedPlan = new SharedPlanApi({
   baseUrl: process.env.SHARED_PLAN_BASE_URL
+});
+
+const VulnerabilitiesApi = require('./gateways/Vulnerabilities/VulnerabilitiesApi');
+const vulnerabilities = new VulnerabilitiesApi({
+  baseUrl: process.env.VULNERABILITIES_BASE_URL
 });
 
 // USECASES
@@ -312,6 +318,20 @@ const findSharedPlans = require('./use-cases/FindSharedPlans')({
   sharedPlan
 });
 
+const createVulnerabilitySnapshot = require('./use-cases/CreateVulnerabilitySnapshot')(
+  {
+    fetchRecords,
+    vulnerabilities
+  }
+);
+
+const findVulnerabilitySnapshots = require('./use-cases/FindVulnerabilitySnapshots')(
+  {
+    fetchRecords,
+    vulnerabilities
+  }
+);
+
 module.exports = {
   Sentry,
   customerSearch,
@@ -321,5 +341,7 @@ module.exports = {
   saveCustomer,
   deleteCustomer,
   createSharedPlan,
-  findSharedPlans
+  findSharedPlans,
+  createVulnerabilitySnapshot,
+  findVulnerabilitySnapshots
 };

--- a/api/lib/use-cases/CreateVulnerabilitySnapshot.js
+++ b/api/lib/use-cases/CreateVulnerabilitySnapshot.js
@@ -1,0 +1,25 @@
+module.exports = ({ fetchRecords, vulnerabilities }) => {
+  return async ({ customerId, token }) => {
+    const record = await fetchRecords(customerId);
+
+    if (!record) {
+      throw new Error('Unable to create vulnerability, unknown customer');
+    }
+
+    const systemIds = [].concat.apply(
+      [customerId],
+      Object.values(record.systemIds)
+    );
+
+    const snapshot = await vulnerabilities.create({
+      customer: {
+        firstName: record.name[0].first,
+        lastName: record.name[0].last,
+        systemIds
+      },
+      token
+    });
+
+    return snapshot;
+  };
+};

--- a/api/lib/use-cases/FindVulnerabilitySnapshots.js
+++ b/api/lib/use-cases/FindVulnerabilitySnapshots.js
@@ -1,0 +1,22 @@
+module.exports = ({ fetchRecords, vulnerabilities }) => {
+  return async ({ customerId, token }) => {
+    const record = await fetchRecords(customerId);
+    if (!record) {
+      throw new Error('Unable to find vulnerabilities, unknown customer');
+    }
+
+    const systemIds = [].concat.apply(
+      [customerId],
+      Object.values(record.systemIds)
+    );
+
+    const { snapshotIds } = await vulnerabilities.find({
+      firstName: record.name[0].first,
+      lastName: record.name[0].last,
+      systemIds,
+      token
+    });
+
+    return { snapshotIds };
+  };
+};

--- a/api/test/gateways/Vulnerabilities/VulnerabilitiesApi.test.js
+++ b/api/test/gateways/Vulnerabilities/VulnerabilitiesApi.test.js
@@ -1,0 +1,75 @@
+const nock = require('nock');
+const VulnerabilitiesApi = require('../../../lib/gateways/Vulnerabilities/VulnerabilitiesApi');
+
+describe('VulnerabilitiesApi', () => {
+  describe('create', () => {
+    const expectedSnapshotId = '1';
+    const expectedToken = 'a-really-secure-token';
+
+    beforeEach(() => {
+      nock('https://vulnerabilities', {
+        reqheaders: {
+          authorization: `Bearer ${expectedToken}`
+        }
+      })
+        .post('/api/vulnerabilities')
+        .reply(201, { id: expectedSnapshotId });
+    });
+
+    it('calls the API endpoint with a valid body', async () => {
+      const api = new VulnerabilitiesApi({
+        baseUrl: 'https://vulnerabilities'
+      });
+      const createdSnapshot = await api.create({
+        token: expectedToken,
+        customer: {
+          firstName: 'Stanley',
+          lastName: 'McTest',
+          systemIds: ['123', '456', '789']
+        }
+      });
+
+      expect(createdSnapshot.id).toBe(expectedSnapshotId);
+      expect(nock.isDone()).toBe(true);
+    });
+  });
+
+  describe('find', () => {
+    const expectedResponse = { snapshotIds: ['1', '2'] };
+    const expectedToken = 'a-really-secure-token';
+
+    beforeEach(() => {
+      nock('https://vulnerabilities', {
+        reqheaders: {
+          Authorization: `Bearer ${expectedToken}`
+        }
+      })
+        .post('/api/vulnerabilities/find')
+        .reply(200, expectedResponse);
+    });
+
+    it('calls the API endpoint with valid body', async () => {
+      const api = new VulnerabilitiesApi({
+        baseUrl: 'https://vulnerabilities'
+      });
+      const { snapshotIds } = await api.find({
+        token: expectedToken,
+        firstName: 'Stanley',
+        lastName: 'McTest',
+        systemIds: ['123', '456']
+      });
+
+      expect(snapshotIds).toStrictEqual(expectedResponse.snapshotIds);
+      expect(nock.isDone()).toBe(true);
+    });
+
+    it('returns an empty array if error', async () => {
+      const api = new VulnerabilitiesApi({
+        baseUrl: 'https://vulnerabilities'
+      });
+      const { snapshotIds } = await api.find({});
+
+      expect(snapshotIds).toStrictEqual([]);
+    });
+  });
+});

--- a/api/test/use-cases/CreateVulnerabilitySnapshot.test.js
+++ b/api/test/use-cases/CreateVulnerabilitySnapshot.test.js
@@ -1,0 +1,65 @@
+const createVulnerabilitySnapshot = require('../../lib/use-cases/CreateVulnerabilitySnapshot');
+
+describe('CreateVulnerabilitySnapshot', () => {
+  const expectedRecord = {
+    id: '123',
+    name: [
+      {
+        first: 'Bob',
+        last: 'Smith'
+      }
+    ],
+    systemIds: {
+      ACADEMY: 'ACADEMY-123',
+      JIGSAW: 'JIGSAW-123'
+    }
+  };
+
+  const expectedSnapshotId = '1';
+  const expectedToken = 'a-very-secure-token';
+
+  it('creates a vulnerability snapshot using the customer details', async () => {
+    const create = jest.fn(() => ({ id: expectedSnapshotId }));
+    const fetchRecords = jest.fn(() => expectedRecord);
+    const execute = createVulnerabilitySnapshot({
+      vulnerabilities: { create },
+      fetchRecords
+    });
+
+    const snapshot = await execute({
+      customerId: expectedRecord.id,
+      token: expectedToken
+    });
+
+    expect(create).toHaveBeenCalledWith({
+      customer: {
+        firstName: expectedRecord.name[0].first,
+        lastName: expectedRecord.name[0].last,
+        systemIds: expect.arrayContaining([
+          expectedRecord.id,
+          expectedRecord.systemIds.ACADEMY,
+          expectedRecord.systemIds.JIGSAW
+        ])
+      },
+      token: expectedToken
+    });
+
+    expect(snapshot.id).toBe(expectedSnapshotId);
+  });
+
+  it('throws an error if customer not found', async () => {
+    const fetchRecords = jest.fn(() => null);
+    const create = jest.fn(() => ({ id: expectedSnapshotId }));
+    const execute = createVulnerabilitySnapshot({
+      fetchRecords,
+      vulnerabilities: { create }
+    });
+
+    await expect(
+      execute({
+        customerId: 1,
+        token: 1
+      })
+    ).rejects.toThrow();
+  });
+});

--- a/api/test/use-cases/FindVulnerabilitySnapshots.test.js
+++ b/api/test/use-cases/FindVulnerabilitySnapshots.test.js
@@ -1,0 +1,62 @@
+const findVulnerabilitySnapshots = require('../../lib/use-cases/FindVulnerabilitySnapshots');
+
+describe('FindVulnerabilitySnapshots', () => {
+  const expectedRecord = {
+    id: '123',
+    name: [
+      {
+        first: 'Test',
+        last: 'Person'
+      }
+    ],
+    systemIds: {
+      ACADEMY: 'ACADEMY-123',
+      JIGSAW: 'JIGSAW-123'
+    }
+  };
+
+  const expectedSnapshotIds = ['123', '456'];
+  const expectedToken = 'a-very-secure-token';
+
+  it('finds vulnerability snapshots using the customer details', async () => {
+    const find = jest.fn(() => ({ snapshotIds: expectedSnapshotIds }));
+    const fetchRecords = jest.fn(() => expectedRecord);
+    const execute = findVulnerabilitySnapshots({
+      vulnerabilities: { find },
+      fetchRecords
+    });
+    const expectedCustomer = {
+      firstName: 'Test',
+      lastName: 'Person',
+      systemIds: ['123', 'ACADEMY-123', 'JIGSAW-123']
+    };
+
+    const { snapshotIds } = await execute({
+      customerId: '123',
+      token: expectedToken
+    });
+
+    expect(find).toHaveBeenCalledWith({
+      ...expectedCustomer,
+      token: expectedToken
+    });
+
+    expect(snapshotIds).toBe(expectedSnapshotIds);
+  });
+
+  it('throws an error if customer not found', async () => {
+    const fetchRecords = jest.fn(() => null);
+    const find = jest.fn(() => ({ snapshotIds: expectedSnapshotIds }));
+    const execute = findVulnerabilitySnapshots({
+      fetchRecords,
+      vulnerabilities: { find }
+    });
+
+    await expect(
+      execute({
+        customerId: 1,
+        token: 1
+      })
+    ).rejects.toThrow();
+  });
+});

--- a/authorizer.js
+++ b/authorizer.js
@@ -1,4 +1,6 @@
-exports.handler = require('node-lambda-authorizer')({
+const authorizer = require('node-lambda-authorizer')({
   jwtSecret: process.env.jwtsecret,
   allowedGroups: process.env.allowedGroups.split(',')
 });
+
+exports.handler = authorizer.handler;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6649,8 +6649,8 @@
       "dev": true
     },
     "node-lambda-authorizer": {
-      "version": "github:LBHackney-IT/node-lambda-authorizer#dfc45f0391d6523d27c130dedcaced855fdc2ee6",
-      "from": "github:LBHackney-IT/node-lambda-authorizer#dfc45f0",
+      "version": "github:LBHackney-IT/node-lambda-authorizer#0fe9e7514882c8ffb4182fa984ee10b99bfd886c",
+      "from": "github:LBHackney-IT/node-lambda-authorizer#0fe9e75",
       "requires": {
         "cookie": "^0.4.0",
         "jsonwebtoken": "^8.5.1"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hn-single-view-api",
   "version": "1.0.0",
   "dependencies": {
-    "node-lambda-authorizer": "LBHackney-IT/node-lambda-authorizer.git#dfc45f0"
+    "node-lambda-authorizer": "LBHackney-IT/node-lambda-authorizer.git#0fe9e75"
   },
   "devDependencies": {
     "nock": "^12.0.3",

--- a/serverless-api.yml
+++ b/serverless-api.yml
@@ -60,6 +60,7 @@ functions:
       ENV: ${self:provider.stage}
       SENTRY_DSN: ${ssm:/hn-single-view-api/SENTRY_DSN}
       SHARED_PLAN_BASE_URL: ${ssm:/hn-single-view-api/${self:provider.stage}/SHARED_PLAN_BASE_URL}
+      VULNERABILITIES_BASE_URL: ${ssm:/hn-single-view-api/${self:provider.stage}/VULNERABILITIES_BASE_URL}
 
   hn-single-view-api-authorizer:
     name: hn-single-view-api-authorizer-${self:provider.stage}


### PR DESCRIPTION
WHAT
Add find/create vulnerabilities endpoints to allow the Single View to find/create vulnerabilities via the vulnerabilities app API

WHY
We need to surface these vulnerabilities in the Single View