### PR TITLE
Updates find snapshots to work with new response

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -23,7 +23,7 @@ if (process.env.ENV === 'staging' || process.env.ENV === 'production') {
 
 app.use(bodyParser.json());
 
-app.use(function(req, res, next) {
+app.use(function (req, res, next) {
   if (req.headers.authorization) {
     res.locals.hackneyToken = req.headers.authorization.replace('Bearer ', '');
   }
@@ -31,7 +31,7 @@ app.use(function(req, res, next) {
 });
 
 // CORS
-app.use(function(req, res, next) {
+app.use(function (req, res, next) {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Credentials', true);
   next();
@@ -173,13 +173,13 @@ app.get('/customers/:id/vulnerabilities', async (req, res, next) => {
     console.time('find-vulnerability-snapshots');
     console.log('find vulnerability snapshots', { params: req.params });
 
-    const { snapshotIds } = await findVulnerabilitySnapshots({
+    const { snapshots } = await findVulnerabilitySnapshots({
       customerId: req.params.id,
       token: res.locals.hackneyToken
     });
 
     console.timeEnd('find-vulnerability-snapshots');
-    return res.send({ snapshotIds });
+    return res.send({ snapshots });
   } catch (err) {
     console.log('find vulnerability snapshots', { error: err });
     next(err);
@@ -196,7 +196,7 @@ if (Sentry) {
   );
 }
 
-app.use(function(err, req, res, next) {
+app.use(function (err, req, res, next) {
   console.log(err);
   res.sendStatus(500);
 });

--- a/api/lib/use-cases/FindVulnerabilitySnapshots.js
+++ b/api/lib/use-cases/FindVulnerabilitySnapshots.js
@@ -10,13 +10,13 @@ module.exports = ({ fetchRecords, vulnerabilities }) => {
       Object.values(record.systemIds)
     );
 
-    const { snapshotIds } = await vulnerabilities.find({
+    const { snapshots } = await vulnerabilities.find({
       firstName: record.name[0].first,
       lastName: record.name[0].last,
       systemIds,
       token
     });
 
-    return { snapshotIds };
+    return { snapshots };
   };
 };

--- a/api/test/use-cases/FindVulnerabilitySnapshots.test.js
+++ b/api/test/use-cases/FindVulnerabilitySnapshots.test.js
@@ -15,11 +15,11 @@ describe('FindVulnerabilitySnapshots', () => {
     }
   };
 
-  const expectedSnapshotIds = ['123', '456'];
+  const expectedSnapshots = [{ id: '123' }, { id: '456' }];
   const expectedToken = 'a-very-secure-token';
 
   it('finds vulnerability snapshots using the customer details', async () => {
-    const find = jest.fn(() => ({ snapshotIds: expectedSnapshotIds }));
+    const find = jest.fn(() => ({ snapshots: expectedSnapshots }));
     const fetchRecords = jest.fn(() => expectedRecord);
     const execute = findVulnerabilitySnapshots({
       vulnerabilities: { find },
@@ -31,7 +31,7 @@ describe('FindVulnerabilitySnapshots', () => {
       systemIds: ['123', 'ACADEMY-123', 'JIGSAW-123']
     };
 
-    const { snapshotIds } = await execute({
+    const { snapshots } = await execute({
       customerId: '123',
       token: expectedToken
     });
@@ -41,12 +41,12 @@ describe('FindVulnerabilitySnapshots', () => {
       token: expectedToken
     });
 
-    expect(snapshotIds).toBe(expectedSnapshotIds);
+    expect(snapshots).toBe(expectedSnapshots);
   });
 
   it('throws an error if customer not found', async () => {
     const fetchRecords = jest.fn(() => null);
-    const find = jest.fn(() => ({ snapshotIds: expectedSnapshotIds }));
+    const find = jest.fn(() => ({ snapshotIds: expectedSnapshots }));
     const execute = findVulnerabilitySnapshots({
       fetchRecords,
       vulnerabilities: { find }


### PR DESCRIPTION
**What**
Updates the find snapshots endpoint to work with the updated vulnerabilities API, which returns a list of snapshots rather than just the ids.

**Why**
So we can display details about the snapshots in Single View without needing to make multiple calls for what are, relatively, small and inexpensive payloads.