### PR TITLE
Add groups to serverless yml

### DIFF
--- a/serverless-api.yml
+++ b/serverless-api.yml
@@ -72,7 +72,10 @@ functions:
         - node_modules/**
     environment:
       jwtsecret: ${ssm:/common/hackney-jwt-secret}
-      allowedGroups: 'housingneeds-singleview-beta'
+      allowedGroups:
+        "Fn::Join":
+          - ','
+          - ${self:custom.allowedGroups.${self:provider.stage}}
       ENV: ${self:provider.stage}
       SENTRY_DSN: ${ssm:/hn-single-view-api/SENTRY_DSN}
 
@@ -90,6 +93,23 @@ resources:
 
 custom:
   stage: ${self:provider.stage}
+  allowedGroups:
+    staging:
+      - contact-centre-staging
+      - benefit-counter-staging
+      - housing-counter-staging
+      - housing-officer-staging
+      - area-housing-manager-staging
+      - housing-needs-staging
+      - housingneeds-singleview-beta
+    production:
+      - contact-centre-production
+      - benefit-counter-production
+      - housing-counter-production
+      - housing-officer-production
+      - area-housing-manager-production
+      - housing-needs-production
+      - housingneeds-singleview-beta
   authorizer:
     hn-single-view-api-authorizer:
       name: hn-single-view-api-authorizer


### PR DESCRIPTION
Adds in more groups and pulls them out into separate variables for staging and prod.

I kept the list as a list to make it easier to work with but then join to a single string for use in an env var.