### PR TITLE
Wire up housing API environment variables in serverless file

### DIFF
--- a/serverless-api.yml
+++ b/serverless-api.yml
@@ -63,6 +63,8 @@ functions:
       VULNERABILITIES_BASE_URL: ${ssm:/hn-single-view-api/${self:provider.stage}/VULNERABILITIES_BASE_URL}
       ACADEMY_API_BASE_URL: ${ssm:/hn-single-view-api/${self:provider.stage}/ACADEMY_API_BASE_URL}
       ACADEMY_API_API_KEY: ${ssm:/hn-single-view-api/${self:provider.stage}/ACADEMY_API_API_KEY}
+      HOUSING_API_BASE_URL: ${ssm:/hn-single-view-api/${self:provider.stage}/HOUSING_API_BASE_URL}
+      HOUSING_API_API_KEY: ${ssm:/hn-single-view-api/${self:provider.stage}/HOUSING_API_API_KEY}
 
   hn-single-view-api-authorizer:
     name: hn-single-view-api-authorizer-${self:provider.stage}


### PR DESCRIPTION
Noticed that the housing API environment variables weren't set up due to this sentry error https://sentry.io/organizations/london-borough-of-hackney/issues/1862422873/?environment=staging&project=2298150&referrer=alert_email
