### PR TITLE
Remove API key authentication in cautionary alerts API gateway

### DIFF
--- a/api/lib/gateways/CautionaryAlerts/CautionaryAlertsApi.js
+++ b/api/lib/gateways/CautionaryAlerts/CautionaryAlertsApi.js
@@ -3,7 +3,6 @@ const rp = require('request-promise');
 module.exports = options => {
   const logger = options.logger;
   const baseUrl = options.baseUrl;
-  const apiKey = options.apiKey;
   const apiToken = options.apiToken;
 
   const alertsForProperty = async propertyRef => {
@@ -13,7 +12,6 @@ module.exports = options => {
         {
           method: 'GET',
           headers: {
-            'X-API-Key': apiKey, //Use API Gateway authorisation
             'Authorization': apiToken //Use Lambda authoriser
           },
           json: true
@@ -33,7 +31,6 @@ module.exports = options => {
       const response = await rp(`${baseUrl}/api/v1/cautionary-alerts/people`, {
         method: 'GET',
         headers: {
-          'X-API-Key': apiKey, //Use API Gateway authorisation
           'Authorization': apiToken //Use Lambda authoriser
         },
         json: true,

--- a/api/lib/libDependencies.js
+++ b/api/lib/libDependencies.js
@@ -209,7 +209,6 @@ const jigsawFetchRecordsGateway = require('./gateways/Jigsaw/FetchRecord')({
   {
     logger: logger,
     baseUrl: process.env.CAUTIONARY_ALERTS_BASE_URL,
-    apiKey: process.env.CAUTIONARY_ALERTS_API_KEY,
     apiToken: process.env.CAUTIONARY_ALERTS_API_TOKEN //Lambda authoriser token
   }
 );*/

--- a/api/test/gateways/CautionaryAlerts/CautionaryAlertsApi.test.js
+++ b/api/test/gateways/CautionaryAlerts/CautionaryAlertsApi.test.js
@@ -41,7 +41,6 @@ describe('CautionaryAlertsApiGateway', () => {
         error: jest.fn((msg, err) => {})
         };
     
-        const apiKey = 'a-really-secure-token';
         const apiToken = 'a-really-secure-token';
         const baseUrl = 'https://universal-housing.com';
     
@@ -50,7 +49,6 @@ describe('CautionaryAlertsApiGateway', () => {
         return CautionaryAlertsApi({
           logger,
           baseUrl,
-          apiKey,
           apiToken,
         });
       };
@@ -59,7 +57,6 @@ describe('CautionaryAlertsApiGateway', () => {
         beforeEach(() => {
           nock(baseUrl, {
             reqheaders: {
-              'X-API-Key': apiKey,
               'Authorization': apiToken
             }
           }).get('/api/v1/cautionary-alerts/people')
@@ -80,7 +77,6 @@ describe('CautionaryAlertsApiGateway', () => {
         beforeEach(() => {
           nock(baseUrl, {
             reqheaders: {
-              'X-API-Key': apiKey,
               'Authorization': apiToken
             }
           }).get('/api/v1/cautionary-alerts/people')
@@ -104,7 +100,6 @@ describe('CautionaryAlertsApiGateway', () => {
           beforeEach(() => {
             nock(baseUrl, {
               reqheaders: {
-                  'X-API-Key': apiKey,
                   'Authorization': apiToken
               }
             }).get(`/api/v1/cautionary-alerts/properties/${propertyRef}`)
@@ -125,7 +120,6 @@ describe('CautionaryAlertsApiGateway', () => {
           beforeEach(() => {
             nock(baseUrl, {
               reqheaders: {
-                  'X-API-Key': apiKey,
                   'Authorization': apiToken
               }
             }).get(`/api/v1/cautionary-alerts/properties/${propertyRef}`)

--- a/serverless-api.yml
+++ b/serverless-api.yml
@@ -67,7 +67,6 @@ functions:
       HOUSING_API_BASE_URL: ${ssm:/hn-single-view-api/${self:provider.stage}/HOUSING_API_BASE_URL}     
       HOUSING_API_API_KEY: ${ssm:/hn-single-view-api/${self:provider.stage}/HOUSING_API_API_KEY}
       CAUTIONARY_ALERTS_BASE_URL: ${ssm:/hn-single-view-api/${self:provider.stage}/CAUTIONARY_ALERTS_BASE_URL}
-      CAUTIONARY_ALERTS_API_KEY: ${ssm:/hn-single-view-api/${self:provider.stage}/CAUTIONARY_ALERTS_API_KEY}
       CAUTIONARY_ALERTS_API_TOKEN: ${ssm:/hn-single-view-api/${self:provider.stage}/CAUTIONARY_ALERTS_API_TOKEN}
       TENANCY_API_BASE_URL: ${ssm:/hn-single-view-api/${self:provider.stage}/TENANCY_API_BASE_URL}
       TENANCY_API_TOKEN: ${ssm:/hn-single-view-api/${self:provider.stage}/TENANCY_API_TOKEN}


### PR DESCRIPTION
Referencing the API key system manager parameter is contributing to failing the staging deploy as the parameter doesn't exist.

As API Key authentication has been removed from the cautionary alerts API we can't add a real API key to parameter store so removing this code instead and just leaving the token-based authentication.