### PR TITLE
Increase limit to 1000 in tenancy api request 

### DIFF
--- a/api/lib/gateways/Tenancies/TenanciesApi.js
+++ b/api/lib/gateways/Tenancies/TenanciesApi.js
@@ -13,7 +13,7 @@ module.exports = options => {
       },
       json: true,
       qs: {
-        limit: 100,
+        limit: 1000,
         cursor,
         address: query.address,
         freehold_only: query.freehold_only,

--- a/api/test/gateways/Tenancies/TenanciesApi.test.js
+++ b/api/test/gateways/Tenancies/TenanciesApi.test.js
@@ -13,7 +13,7 @@ describe('Tenancies API', () => {
         'Accept': 'application/json'
       }
     }).get('/api/v1/tenancies')
-      .query({ ...queryParams, limit: 100 })
+      .query({ ...queryParams, limit: 1000 })
       .reply(200, { tenancies, nextCursor })
   }
 
@@ -24,7 +24,7 @@ describe('Tenancies API', () => {
         'Accept': 'application/json'
       }
     }).get('/api/v1/tenancies')
-      .query({ ...queryParams, limit: 100 })
+      .query({ ...queryParams, limit: 1000 })
       .reply(500, 'Really bad error')
   }
 


### PR DESCRIPTION
There are a _lot_ of tenancies, retrieving them 100 at a time from the API was too slow. In the future it will probably be worth using the API's pagination to paginate in the UI instead of retrieving all records at once, to prevent timeouts.