### PR TITLE
Add token based auth when calling housing API

### DIFF
--- a/api/lib/gateways/UHT-Contacts/SearchApi.js
+++ b/api/lib/gateways/UHT-Contacts/SearchApi.js
@@ -5,6 +5,7 @@ module.exports = options => {
   const logger = options.logger;
   const apiKey = options.apiKey;
   const baseUrl = options.baseUrl;
+  const token = options.token;
   const buildSearchRecord = options.buildSearchRecord;
 
   const search = async queryParams => {
@@ -26,7 +27,8 @@ module.exports = options => {
     return await rp(`${baseUrl}/api/v1/households`, {
       method: 'GET',
       headers: {
-        'X-API-Key': apiKey
+        'X-API-Key': apiKey,
+        'Authorization': `Bearer ${token}`
       },
       json: true,
       qs: {

--- a/api/lib/libDependencies.js
+++ b/api/lib/libDependencies.js
@@ -76,6 +76,7 @@ const academyBenefitsSearchGateway = require('./gateways/Academy-Benefits/Search
 const uhtContactsSearchApi = require('./gateways/UHT-Contacts/SearchApi')({
   baseUrl: process.env.HOUSING_API_BASE_URL,
   apiKey: process.env.HOUSING_API_API_KEY,
+  token: process.env.HOUSING_API_TOKEN,
   buildSearchRecord,
   logger
 });

--- a/api/test/gateways/Academy-Benefits/FetchCustomerAPI.test.js
+++ b/api/test/gateways/Academy-Benefits/FetchCustomerAPI.test.js
@@ -8,13 +8,13 @@ describe('AcademyBenefitsFetchRecord gateway', () => {
   const createGateway = (customer, personRef, claimId) => {
     const baseUrl = 'https://test-domain.com';
     const apiToken = 'anbdabkd';
-    const mockRequest =
-      nock(baseUrl, {
-        reqHeaders: {
-          'Authorization': `Bearer ${apiToken}`
-        }
-      }).get(`/api/v1/claim/${claimId}/person/${personRef}`)
-        .reply(200, customer);
+
+    nock(baseUrl, {
+      reqheaders: {
+        'Authorization': `Bearer ${apiToken}`
+      }
+    }).get(`/api/v1/claim/${claimId}/person/${personRef}`)
+      .reply(200, customer);
 
     logger = {
       error: jest.fn((msg, err) => { })

--- a/api/test/gateways/Academy-Benefits/Search.test.js
+++ b/api/test/gateways/Academy-Benefits/Search.test.js
@@ -9,7 +9,7 @@ describe('AcademyBenefitsSearchGateway', () => {
 
   const mockRequest = (claimants, queryParams, nextCursor) => {
     nock(baseUrl, {
-      reqHeaders: {
+      reqheaders: {
         'Authorization': `Bearer ${apiToken}`
       }
     }).get('/api/v1/claimants')
@@ -19,7 +19,7 @@ describe('AcademyBenefitsSearchGateway', () => {
 
   const mockRequestError = () => {
     nock(baseUrl, {
-      reqHeaders: {
+      reqheaders: {
         'Authorization': `Bearer ${apiToken}`
       }
     }).get('/api/v1/claimants')

--- a/api/test/gateways/UHT-Contacts/SearchApi.test.js
+++ b/api/test/gateways/UHT-Contacts/SearchApi.test.js
@@ -6,6 +6,7 @@ describe('UHTContactsSearchAPIGateway', () => {
   let logger;
   const baseUrl = 'https://universal-housing.com';
   const apiKey = 'secret-secret-secret';
+  const token = 'very-secret-token';
   const fullApiResponse = {
     houseReference: '123',
     personNumber: 3,
@@ -33,8 +34,9 @@ describe('UHTContactsSearchAPIGateway', () => {
   }
   const mockRequest = (households, queryParams, nextCursor = '') => {
     nock(baseUrl, {
-      reqHeaders: {
-        'X-API-Key': apiKey
+      reqheaders: {
+        'X-API-Key': apiKey,
+        'Authorization': `Bearer ${token}`
       }
     }).get('/api/v1/households')
     .query({...queryParams, limit: 100})
@@ -42,8 +44,9 @@ describe('UHTContactsSearchAPIGateway', () => {
   }
   const mockRequestError = (queryParams) => {
     nock(baseUrl, {
-      reqHeaders: {
-        'X-API-Key': apiKey
+      reqheaders: {
+        'X-API-Key': apiKey,
+        'Authorization': `Bearer ${token}`
       }
     }).get('/api/v1/households')
     .query({...queryParams, limit: 100})
@@ -69,6 +72,7 @@ describe('UHTContactsSearchAPIGateway', () => {
       buildSearchRecord,
       baseUrl,
       apiKey,
+      token,
       logger
     });
   };

--- a/serverless-api.yml
+++ b/serverless-api.yml
@@ -64,6 +64,7 @@ functions:
       ACADEMY_API_BASE_URL: ${ssm:/hn-single-view-api/${self:provider.stage}/ACADEMY_API_BASE_URL}
       ACADEMY_API_API_TOKEN: ${ssm:/hn-single-view-api/${self:provider.stage}/ACADEMY_API_API_TOKEN}
       HOUSING_API_BASE_URL: ${ssm:/hn-single-view-api/${self:provider.stage}/HOUSING_API_BASE_URL}     
+      HOUSING_API_TOKEN: ${ssm:/hn-single-view-api/${self:provider.stage}/HOUSING_API_TOKEN}
       HOUSING_API_API_KEY: ${ssm:/hn-single-view-api/${self:provider.stage}/HOUSING_API_API_KEY}
       CAUTIONARY_ALERTS_BASE_URL: ${ssm:/hn-single-view-api/${self:provider.stage}/CAUTIONARY_ALERTS_BASE_URL}
       CAUTIONARY_ALERTS_API_TOKEN: ${ssm:/hn-single-view-api/${self:provider.stage}/CAUTIONARY_ALERTS_API_TOKEN}


### PR DESCRIPTION
Leaving both authentication types in place whilst switching over the housing API to use token. When this work is finished will remove the API key header.